### PR TITLE
Add filter to allow user role restriction on publicize to be overridden

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -22,8 +22,17 @@ class Publicize_UI {
 	}
 
 	function init() {
-		// Show only to users with the capability required to manage their Publicize connections.  Filter to allow for custom roles. 
-		$capability = apply_filters( 'publicize_capability', 'publish_posts' );
+		// Show only to users with the capability required to manage their Publicize connections.
+		/**
+		 * Filter what user capability is required to use the publicize form on the edit post page. Useful if publish post capability has been removed from role.
+		 *
+		 * @module publicize
+		 *
+		 * @since 4.0.2
+		 *
+		 * @param string $capability User capability needed to use publicize
+		 */
+		$capability = apply_filters( 'jetpack_publicize_capability', 'publish_posts' );
 		if ( ! current_user_can( $capability ) ) {
 			return;
 		}

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -22,8 +22,9 @@ class Publicize_UI {
 	}
 
 	function init() {
-		// Show only to users with the capability required to manage their Publicize connections.
-		if ( ! current_user_can( 'publish_posts' ) ) {
+		// Show only to users with the capability required to manage their Publicize connections.  Filter to allow for custom roles. 
+		$capability = apply_filters( 'publicize_capability', 'publish_posts' );
+		if ( ! current_user_can( $capability ) ) {
 			return;
 		}
 


### PR DESCRIPTION
No related GH issue.

It would make more sense to allow publicize to appear on the 'edit_posts' capability than 'publish_posts'.  We have a site where 'publish_posts' has been removed from the Author role so that Editors can schedule posts, but by default they can't make connections or draft publicize messages.
#### Changes proposed in this Pull Request:

Rather than retroactively change this, this filter allows for overriding the default with a filter

```
/**
 * Modifies JetPack Publicize Module to required capability for custom user role
 * @return string user role
 */
function jb_publicize_capability() {
    return 'edit_posts';
}
add_filter( 'publicize_capability', 'jb_publicize_capability' );
```
